### PR TITLE
Fix a bug where the "use civilian colors" toggle wasn't respected

### DIFF
--- a/unitgenerator/index.html
+++ b/unitgenerator/index.html
@@ -666,12 +666,12 @@
 
         <section class="switch">
             <div class="mdc-switch">
-                <input type="checkbox" id="civilianColors" class="mdc-switch__native-control" checked />
+                <input type="checkbox" id="civilianColor" class="mdc-switch__native-control" checked />
                 <div class="mdc-switch__background">
                     <div class="mdc-switch__knob"></div>
                 </div>
             </div>
-            <label for="civilianColors" class="mdc-switch-label">Use civilian colors for civilian symbols</label>
+            <label for="civilianColor" class="mdc-switch-label">Use civilian colors for civilian symbols</label>
         </section>
 
         <section class="switch">


### PR DESCRIPTION
There is a typo in the generator HTML that causes the "use civilian colors" toggle to be ignored, and therefore always treated as "on", so the purple color would always be used for civilian units. The generator HTML uses "`civilianColors`" whereas the `milsymbol` library expects the style option to be called "`civilianColor`".
This change fixes that so that toggling off "use civilian colors" now works as expected.
Tested locally, built with `npm`, fix observed working in Chrome.